### PR TITLE
Make ffi-napi optional depending on USE_STARKWARE_CRYPTO_CPP

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,6 +26,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: npm install
+    - run: USE_STARKWARE_CRYPTO_CPP=true npm install
     - run: npm test
     - run: USE_STARKWARE_CRYPTO_CPP=true npm test

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ const signature = signLimitOrder(privateKey, limitOrder);
 
 # C++ bindings
 
-Starting from v1.2.0, C++ bindings can be used for faster `verifyTransfer` and `verifyLimitOrder` operations. It uses Starkware's [crypto-cpp](https://github.com/starkware-libs/crypto-cpp) library and can be enabled by adding `USE_STARKWARE_CRYPTO_CPP=true` to your env. Please also note that `yarn install` will build C++ bindings (using [node-gyp](https://github.com/nodejs/node-gyp)) starting from this version.
+Starting from v1.3.2, C++ bindings can be used for faster `verifyTransfer` and `verifyLimitOrder` operations. It uses Starkware's [crypto-cpp](https://github.com/starkware-libs/crypto-cpp) library and can be enabled by adding `USE_STARKWARE_CRYPTO_CPP=true` to your env. Please note that this variable also needs to be set when `yarn install` runs in order to build the C++ bindings using [node-gyp](https://github.com/nodejs/node-gyp).
 
 # License
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Crypto used in the Sorare stack",
   "author": "Sorare",
   "license": "MIT",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "lib.js",
   "dependencies": {
     "bigint-buffer": "^1.1.5",
@@ -56,6 +56,7 @@
     "build:types": "tsc --emitDeclarationOnly",
     "build:js": "babel src --out-dir dist --extensions \".js,.ts\" --source-maps inline",
     "prepublish": "yarn run build",
+    "install": "(test -n \"$USE_STARKWARE_CRYPTO_CPP\" && node-gyp rebuild) || true",
     "postinstall": "patch-package",
     "test": "jest ./src",
     "package": "yarn build && rm dist/index.test.* && yarn pack",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "elliptic": "^6.5.4",
     "enc-utils": "^3.0.0",
     "ethereumjs-wallet": "^1.0.1",
-    "ffi-napi": "^3.1.0",
+    "ffi-napi": "^4.0.3",
     "hash.js": "^1.1.7",
     "patch-package": "^6.4.7"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,6 @@ import hash from 'hash.js';
 import { LimitOrder, Transfer, Signature } from './types';
 import { getAccountPath, getKeyPairFromPath } from './starkware/keyDerivation';
 import {
-  useCryptoCpp,
   starkEc,
   pedersen,
   sign as starkSign,
@@ -17,7 +16,7 @@ import {
   getLimitOrderMsgHash,
   getLimitOrderMsgHashWithFee,
 } from './starkware/signature';
-import { verify as starkVerifyCpp } from './starkware/crypto';
+import { verify as starkVerifyCpp, useCryptoCpp } from './starkware/crypto';
 
 export { LimitOrder, Transfer, Signature } from './types';
 

--- a/src/starkware/crypto.js
+++ b/src/starkware/crypto.js
@@ -18,18 +18,26 @@ const path = require('path');
 const BN = require('bn.js');
 const BigIntBuffer = require('bigint-buffer');
 const assert = require('assert');
-const ffi = require('ffi-napi');
 
-// Native crypto bindings.
-const libcrypto = ffi.Library(
-  path.join(__dirname, '..', '..', 'build', 'Release', 'crypto'),
-  {
-    Hash: ['int', ['string', 'string', 'string']],
-    Verify: ['bool', ['string', 'string', 'string', 'string']],
-    Sign: ['int', ['string', 'string', 'string', 'string']],
-    GetPublicKey: ['int', ['string', 'string']],
-  }
-);
+const useCryptoCpp = Boolean(process.env.USE_STARKWARE_CRYPTO_CPP);
+let libcrypto;
+
+// Only load FFI bindings if we run in a Node environment and we asked for it
+if (useCryptoCpp) {
+  // eslint-disable-next-line
+  const ffi = require('ffi-napi');
+
+  // Native crypto bindings.
+  libcrypto = ffi.Library(
+    path.join(__dirname, '..', '..', 'build', 'Release', 'crypto'),
+    {
+      Hash: ['int', ['string', 'string', 'string']],
+      Verify: ['bool', ['string', 'string', 'string', 'string']],
+      Sign: ['int', ['string', 'string', 'string', 'string']],
+      GetPublicKey: ['int', ['string', 'string']],
+    }
+  );
+}
 
 const curveOrder = new BN(
   '800000000000010ffffffffffffffffb781126dcae7b2321e66a241adc64d2f',
@@ -103,4 +111,5 @@ module.exports = {
   sign,
   verify,
   getPublicKey,
+  useCryptoCpp,
 };

--- a/src/starkware/signature.js
+++ b/src/starkware/signature.js
@@ -20,9 +20,7 @@ import { curves as eCurves, ec as EllipticCurve } from 'elliptic';
 import assert from 'assert';
 
 import constantPointsHex from './constant_points';
-import { pedersen as pedersenCpp } from './crypto';
-
-export const useCryptoCpp = Boolean(process.env.USE_STARKWARE_CRYPTO_CPP);
+import { pedersen as pedersenCpp, useCryptoCpp } from './crypto';
 
 // Equals 2**251 + 17 * 2**192 + 1.
 export const prime = new BN(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2834,16 +2834,16 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-ffi-napi@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/ffi-napi/-/ffi-napi-3.1.0.tgz#5bd037a26eaa4234c664e8b9d27be3719505c7bd"
-  integrity sha512-EsHO+sP2p/nUC/3l/l8m9niee1BLm4asUFDzkkBGR4kYVgp2KqdAYUomZhkKtzim4Fq7mcYHjpUaIHsMqs+E1g==
+ffi-napi@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/ffi-napi/-/ffi-napi-4.0.3.tgz#27a8d42a8ea938457154895c59761fbf1a10f441"
+  integrity sha512-PMdLCIvDY9mS32RxZ0XGb95sonPRal8aqRhLbeEtWKZTe2A87qRFG9HjOhvG8EX2UmQw5XNRMIOT+1MYlWmdeg==
   dependencies:
     debug "^4.1.1"
     get-uv-event-loop-napi-h "^1.0.5"
-    node-addon-api "^2.0.0"
+    node-addon-api "^3.0.0"
     node-gyp-build "^4.2.1"
-    ref-napi "^2.0.1"
+    ref-napi "^2.0.1 || ^3.0.2"
     ref-struct-di "^1.1.0"
 
 file-entry-cache@^6.0.1:
@@ -4189,6 +4189,11 @@ node-addon-api@^2.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
 
+node-addon-api@^3.0.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
+  integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
+
 node-gyp-build@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.3.0.tgz#9f256b03e5826150be39c764bf51e993946d71a3"
@@ -4588,14 +4593,14 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
-ref-napi@^2.0.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/ref-napi/-/ref-napi-2.1.2.tgz#5986069d7b0ea83e1fef48239a2bd75318ce341b"
-  integrity sha512-aFl+vrIuLWUXMUTQGAwGAuSNLX3Ub5W3iVP8b7KyFFZUdn4+i4U1TXXTop0kCTUfGNu8glBGVz4lowkwMcPVVA==
+"ref-napi@^2.0.1 || ^3.0.2":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/ref-napi/-/ref-napi-3.0.3.tgz#e259bfc2bbafb3e169e8cd9ba49037dd00396b22"
+  integrity sha512-LiMq/XDGcgodTYOMppikEtJelWsKQERbLQsYm0IOOnzhwE9xYZC7x8txNnFC9wJNOkPferQI4vD4ZkC0mDyrOA==
   dependencies:
     debug "^4.1.1"
     get-symbol-from-current-process-h "^1.0.2"
-    node-addon-api "^2.0.0"
+    node-addon-api "^3.0.0"
     node-gyp-build "^4.2.1"
 
 ref-struct-di@^1.1.0:


### PR DESCRIPTION
This change makes sure the library can run in a browser environment by ignoring `ffi-napi` if `USE_STARKWARE_CRYPTO_CPP` is not set. Also, `yarn install` does not compile C++ bindings if the variable is not set (as they won't be used anyway). 