### PR TITLE
Fix invalid char when getTransferMsgHashWithFee with condition

### DIFF
--- a/src/starkware/signature.js
+++ b/src/starkware/signature.js
@@ -490,7 +490,7 @@ export function getTransferMsgHashWithFee(
   let cond = null;
   if (condition) {
     cond = condition.substring(2);
-    assertInRange(new BN(cond), zeroBn, prime, 'condition');
+    assertInRange(new BN(cond, 16), zeroBn, prime, 'condition');
     instructionType = fiveBn;
   }
   return hashTransferMsgWithFee(


### PR DESCRIPTION
Use the same logic as above in `getTransferMsgHash` to deal with condition. 

Error : 
```
bn.js:6 Uncaught (in promise) Error: Invalid character
    at assert (bn.js:6:21)
    at parseBase (bn.js:274:7)
    at BN._parseBase (bn.js:298:14)
    at BN.init [as _init] (bn.js:105:14)
    at new BN (bn.js:39:12)
    at getTransferMsgHashWithFee (signature.js:493:19)
    at hashTransfer2 (index.ts:81:12)
    at signTransfer2 (index.ts:173:19)
    at StarkwareWallet.signTransfer (index.ts:37:12)
    at index.tsx:339:45
```